### PR TITLE
Add --no-build-logs option to disable writing builds logs to stdout of Jenkins

### DIFF
--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -71,7 +71,8 @@ public class PipelineRunOptions extends PipelineOptions {
             description = "The Pipeline Configuration File when using the Jenkins Templating Engine")
     public File pipelineConfiguration;
 
-    @CommandLine.Option(names = { "-nso", "--no-stdout" },
-            description = "Disable writing logs to stdout of Jenkins")
-    public boolean noStdout = false;
+    @CommandLine.Option(names = { "-nbl", "--no-build-logs" },
+            description = "Disable writing build logs to stdout. " +
+                    "Plugins that handle build logs will process them as usual")
+    public boolean noBuildLogs = false;
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -70,4 +70,8 @@ public class PipelineRunOptions extends PipelineOptions {
     @CommandLine.Option(names = { "-pc", "--pipeline-configuration" },
             description = "The Pipeline Configuration File when using the Jenkins Templating Engine")
     public File pipelineConfiguration;
+
+    @CommandLine.Option(names = { "-nso", "--no-stdout" },
+            description = "Disable writing logs to stdout of Jenkins")
+    public boolean noStdout = false;
 }

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -118,7 +118,7 @@ public class Runner {
 
         b = f.getStartCondition().get();
 
-        if (!runOptions.noStdout) {
+        if (!runOptions.noBuildLogs) {
           writeLogTo(System.out);
         }
 

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -118,7 +118,9 @@ public class Runner {
 
         b = f.getStartCondition().get();
 
-        writeLogTo(System.out);
+        if (!runOptions.noStdout) {
+          writeLogTo(System.out);
+        }
 
         f.get();    // wait for the completion
         return b.getResult().ordinal;


### PR DESCRIPTION
A new jenkinsfile-runner image [TEST_230607_6a60c06](https://hub.docker.com/layers/stewardci/stewardci-jenkinsfile-runner/TEST_230607_6a60c06/images/sha256-693c3ed671fc48542b1f8cc27d5f625a901d38879f4fc4852c9c31dd5e9cb5cd?context=explore) was created via a temporary PR [SAP/stewardci-jenkinsfilerunner-image/pull/106](https://github.com/SAP/stewardci-jenkinsfilerunner-image/pull/106).  I replaced `jenkinsfileRunner.image` in `steward-pipelineruns` config map in `steward-system` namespace on my dev cluster to test the image.
The build logs which are forwarded to Opensearch build index, appear only in Opensearch but not in the logs of jenkinsfile-runner container.
Basically, every log line starting with the following, went only to Opensearch.
```
Jun 7, 2023 @ 18:10:01.143	 - 
Jun 7, 2023 @ 18:10:01.553	Started
Jun 7, 2023 @ 18:10:01.859	Resume disabled by user, switching to high-performance, low-durability mode.
Jun 7, 2023 @ 18:10:06.376	[Pipeline] Start of Pipeline
...
```
