### PR TITLE
Add --write-log-init-timeout option

### DIFF
--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -77,7 +77,7 @@ public class PipelineRunOptions extends PipelineOptions {
     public boolean noBuildLogs = false;
 
     @CommandLine.Option(names = { "-wlrd", "--write-log-retry-duration" },
-            description = "Initializing build log forwarding to stdout may fail if the build log has not been created yet. This option sets an overall duration in seconds for retries. A delay between retries is 100ms.
-Duration in seconds to retry writing logs to output stream.")
+            description = "Initializing build log forwarding to stdout may fail if the build log has not been created yet. " +
+                    "This option sets an overall duration in seconds for retries. A delay between retries is 100ms")
     public int writeLogRetryDuration = 1;
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -76,8 +76,9 @@ public class PipelineRunOptions extends PipelineOptions {
                     "Plugins that handle build logs will process them as usual")
     public boolean noBuildLogs = false;
 
-    @CommandLine.Option(names = { "-wlrd", "--write-log-retry-duration" },
+    @CommandLine.Option(names = { "-wlit", "--write-log-init-timeout" },
             description = "Initializing build log forwarding to stdout may fail if the build log has not been created yet. " +
-                    "This option sets an overall duration in seconds for retries. A delay between retries is 100ms")
-    public int writeLogRetryDuration = 1;
+                    " This option defines the maximum time (in seconds) to wait for build log creation." +
+                    " Defaults to 1 second.")
+    public int writeLogInitTimeoutSeconds = 1;
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -76,7 +76,7 @@ public class PipelineRunOptions extends PipelineOptions {
                     "Plugins that handle build logs will process them as usual")
     public boolean noBuildLogs = false;
 
-    @CommandLine.Option(names = { "-wlrc", "--write-log-retry-count" },
-            description = "Retry count for writing logs to output stream.")
-    public int writeLogRetryCount = 10;
+    @CommandLine.Option(names = { "-wlrd", "--write-log-retry-duration" },
+            description = "Duration in seconds to retry writing logs to output stream.")
+    public int writeLogRetryDuration = 60;
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -77,6 +77,7 @@ public class PipelineRunOptions extends PipelineOptions {
     public boolean noBuildLogs = false;
 
     @CommandLine.Option(names = { "-wlrd", "--write-log-retry-duration" },
-            description = "Duration in seconds to retry writing logs to output stream.")
-    public int writeLogRetryDuration = 60;
+            description = "Initializing build log forwarding to stdout may fail if the build log has not been created yet. This option sets an overall duration in seconds for retries. A delay between retries is 100ms.
+Duration in seconds to retry writing logs to output stream.")
+    public int writeLogRetryDuration = 1;
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -75,4 +75,8 @@ public class PipelineRunOptions extends PipelineOptions {
             description = "Disable writing build logs to stdout. " +
                     "Plugins that handle build logs will process them as usual")
     public boolean noBuildLogs = false;
+
+    @CommandLine.Option(names = { "-wlrc", "--write-log-retry-count" },
+            description = "Retry count for writing logs to output stream.")
+    public int writeLogRetryCount = 10;
 }

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -119,7 +119,7 @@ public class Runner {
         b = f.getStartCondition().get();
 
         if (!runOptions.noBuildLogs) {
-          writeLogTo(System.out, runOptions.writeLogRetryDuration);
+          writeLogTo(System.out, runOptions.writeLogInitTimeoutSeconds);
         }
 
         f.get();    // wait for the completion
@@ -156,13 +156,13 @@ public class Runner {
       return new CauseAction(c);
     }
 
-    private void writeLogTo(PrintStream out, int retryDuration) throws IOException, InterruptedException {
+    private void writeLogTo(PrintStream out, int timeoutSeconds) throws IOException, InterruptedException {
         // read output in a retry loop,
         // writeWholeLogTo may fail with FileNotFound
         // exception on a slow/busy machine, if it takes
         // longish to create the log file
         int retryInterval = 100;
-        long durationMillis = retryDuration * 1000;
+        long timeoutMillis = timeoutSeconds * 1000;
         long startTime = System.currentTimeMillis(); 
         while (true) {
             try {
@@ -170,7 +170,7 @@ public class Runner {
                 break;
             }
             catch (FileNotFoundException | NoSuchFileException e) {
-                if ( System.currentTimeMillis() - startTime > durationMillis ) {
+                if ( System.currentTimeMillis() - startTime > timeoutMillis ) {
                     throw e;
                 }
                 Thread.sleep(retryInterval);

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -119,7 +119,7 @@ public class Runner {
         b = f.getStartCondition().get();
 
         if (!runOptions.noBuildLogs) {
-          writeLogTo(System.out);
+          writeLogTo(System.out, runOptions.writeLogRetryCount);
         }
 
         f.get();    // wait for the completion
@@ -156,9 +156,7 @@ public class Runner {
       return new CauseAction(c);
     }
 
-    private void writeLogTo(PrintStream out) throws IOException, InterruptedException {
-        final int retryCnt = 10;
-
+    private void writeLogTo(PrintStream out, int retryCnt) throws IOException, InterruptedException {
         // read output in a retry loop, by default try only once
         // writeWholeLogTo may fail with FileNotFound
         // exception on a slow/busy machine, if it takes

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -119,7 +119,7 @@ public class Runner {
         b = f.getStartCondition().get();
 
         if (!runOptions.noBuildLogs) {
-          writeLogTo(System.out, runOptions.writeLogRetryCount);
+          writeLogTo(System.out, runOptions.writeLogRetryDuration);
         }
 
         f.get();    // wait for the completion
@@ -156,22 +156,23 @@ public class Runner {
       return new CauseAction(c);
     }
 
-    private void writeLogTo(PrintStream out, int retryCnt) throws IOException, InterruptedException {
-        // read output in a retry loop, by default try only once
+    private void writeLogTo(PrintStream out, int retryDuration) throws IOException, InterruptedException {
+        // read output in a retry loop,
         // writeWholeLogTo may fail with FileNotFound
         // exception on a slow/busy machine, if it takes
         // longish to create the log file
         int retryInterval = 100;
-        for (int i=0;i<=retryCnt;) {
+        long durationMillis = retryDuration * 1000;
+        long startTime = System.currentTimeMillis(); 
+        while (true) {
             try {
                 b.writeWholeLogTo(out);
                 break;
             }
             catch (FileNotFoundException | NoSuchFileException e) {
-                if ( i == retryCnt ) {
+                if ( System.currentTimeMillis() - startTime > durationMillis ) {
                     throw e;
                 }
-                i++;
                 Thread.sleep(retryInterval);
             }
         }


### PR DESCRIPTION
The new option allows the consumer to define how long the build log forwarding write loop will retry if the build log file doesn't exist yet. This replaces a hard-coded default which in some cases is too short.